### PR TITLE
Adding multiple scene setup for the viewport

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -320,6 +320,14 @@ Column 0  Sort=0v
 RefScale=16
 Column 0  Sort=0v
 
+[Table][0x48A4FEBC,4]
+RefScale=16
+Column 0  Sort=0v
+
+[Table][0xAE11EEB7,4]
+RefScale=16
+Column 0  Sort=0v
+
 [Docking][Data]
 DockSpace                   ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,24 Size=1920,980 Split=X Selected=0xFFEA1EA4
   DockNode                  ID=0x00000017 Parent=0x8B93E3BD SizeRef=1498,1004 Split=X
@@ -346,7 +354,7 @@ DockSpace                   ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,24 Size=1920,9
             DockNode        ID=0x00000001 Parent=0x00000002 SizeRef=1198,796 Split=Y Selected=0x80C34F4E
               DockNode      ID=0x00000013 Parent=0x00000001 SizeRef=1159,796 Split=Y Selected=0x80C34F4E
                 DockNode    ID=0x00000027 Parent=0x00000013 SizeRef=1070,747 Split=Y Selected=0x80C34F4E
-                  DockNode  ID=0x00000029 Parent=0x00000027 SizeRef=1070,747 CentralNode=1 Selected=0x80C34F4E
+                  DockNode  ID=0x00000029 Parent=0x00000027 SizeRef=1070,671 CentralNode=1 Selected=0x80C34F4E
                   DockNode  ID=0x0000002A Parent=0x00000027 SizeRef=1070,100 Selected=0x625FFC87
                 DockNode    ID=0x00000028 Parent=0x00000013 SizeRef=1070,100 Selected=0x7A443D91
               DockNode      ID=0x00000014 Parent=0x00000001 SizeRef=1159,207 Selected=0xF6B7AC0D

--- a/imgui.ini
+++ b/imgui.ini
@@ -328,6 +328,10 @@ Column 0  Sort=0v
 RefScale=16
 Column 0  Sort=0v
 
+[Table][0x3E15C06B,4]
+RefScale=16
+Column 0  Sort=0v
+
 [Docking][Data]
 DockSpace                   ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,24 Size=1920,980 Split=X Selected=0xFFEA1EA4
   DockNode                  ID=0x00000017 Parent=0x8B93E3BD SizeRef=1498,1004 Split=X

--- a/premake5.lua
+++ b/premake5.lua
@@ -347,6 +347,8 @@ project "imgui"
 		"libs/imgui/imstb_rectpack.h",
 		"libs/imgui/imstb_textedit.h",
 		"libs/imgui/imstb_truetype.h",
+		"libs/imgui/misc/cpp/imgui_stdlib.h",
+		"libs/imgui/misc/cpp/imgui_stdlib.cpp",
 		"libs/imgui/imgui.cpp",
 		"libs/imgui/imgui_draw.cpp",
 		"libs/imgui/imgui_tables.cpp",

--- a/sprout_editor/assets/scenes/Sponza.mag.json
+++ b/sprout_editor/assets/scenes/Sponza.mag.json
@@ -26,7 +26,7 @@
                 "Fov": 60.0,
                 "Near": 1.0,
                 "Far": 10000.0,
-                "AspectRatio": 1.6537866592407227
+                "AspectRatio": 1.7285945415496826
             },
             "ScriptComponent": {
                 "FilePath": "sprout_editor/assets/scripts/example_lua_script.lua"

--- a/sprout_editor/assets/scenes/Test.mag.json
+++ b/sprout_editor/assets/scenes/Test.mag.json
@@ -1,5 +1,5 @@
 {
-    "Scene": "Untitled",
+    "Scene": "Test",
     "Entities": [
         {
             "NameComponent": {
@@ -26,7 +26,7 @@
                 "Fov": 60.0,
                 "Near": 1.0,
                 "Far": 10000.0,
-                "AspectRatio": 1.6537866592407227
+                "AspectRatio": 1.7285945415496826
             },
             "ScriptComponent": {
                 "FilePath": "sprout_editor/assets/scripts/example_lua_script.lua"

--- a/sprout_editor/assets/scenes/Untitled.mag.json
+++ b/sprout_editor/assets/scenes/Untitled.mag.json
@@ -1,3 +1,0 @@
-{
-    "Scene": "Untitled"
-}

--- a/sprout_editor/assets/scenes/Untitled.mag.json
+++ b/sprout_editor/assets/scenes/Untitled.mag.json
@@ -1,0 +1,3 @@
+{
+    "Scene": "Untitled"
+}

--- a/sprout_editor/src/editor.cpp
+++ b/sprout_editor/src/editor.cpp
@@ -128,7 +128,7 @@ namespace sprout
     {
         Scene *scene = new Scene();
         SceneSerializer scene_serializer(*scene);
-        scene_serializer.deserialize("sprout_editor/assets/scenes/test_scene.mag.json");
+        scene_serializer.deserialize("sprout_editor/assets/scenes/Test.mag.json");
 
         add_scene(scene);
         set_active_scene(0);
@@ -180,10 +180,29 @@ namespace sprout
         EventDispatcher dispatcher(e);
         dispatcher.dispatch<NativeEvent>(BIND_FN(Editor::on_sdl_event));
         dispatcher.dispatch<WindowResizeEvent>(BIND_FN(Editor::on_resize));
+        dispatcher.dispatch<QuitEvent>(BIND_FN(Editor::on_quit));
 
         get_active_scene().on_event(e);
         menu_bar->on_event(e);
         viewport_panel->on_event(e);
+    }
+
+    // @TODO: use file dialogs to ask about saving files when the file dialog is implemented. For now this is a
+    // temporary solution to avoid losing work after closing. Also the scene names must be different form one another or
+    // else the files will be overwritten.
+    void Editor::on_quit(QuitEvent &e)
+    {
+        (void)e;
+
+        // Save open scenes
+        for (auto &scene : open_scenes)
+        {
+            // @TODO: hardcoded path
+            const str file_path = "sprout_editor/assets/scenes/" + scene->get_name() + ".mag.json";
+
+            SceneSerializer serializer(*scene);
+            serializer.serialize(file_path);
+        }
     }
 
     void Editor::on_sdl_event(NativeEvent &e) { ImGui_ImplSDL2_ProcessEvent(reinterpret_cast<const SDL_Event *>(e.e)); }

--- a/sprout_editor/src/editor.hpp
+++ b/sprout_editor/src/editor.hpp
@@ -61,6 +61,7 @@ namespace sprout
 
             void on_sdl_event(NativeEvent& e);
             void on_resize(WindowResizeEvent& e);
+            void on_quit(QuitEvent& e);
             void on_viewport_resize(const uvec2& new_viewport_size);
 
             void set_active_scene(const u32 index);

--- a/sprout_editor/src/editor.hpp
+++ b/sprout_editor/src/editor.hpp
@@ -33,15 +33,18 @@ namespace sprout
             virtual void on_update(const f32 dt) override;
             virtual void on_event(Event& e) override;
 
-            void enqueue_scene(Scene* scene);
+            void add_scene(Scene* scene);
 
             void set_input_disabled(const b8 disable);
+            void set_selected_scene_index(const u32 index);
 
             // @TODO: this can be extended to query by window name if needed
             b8 is_viewport_window_active() const;
 
-            Scene& get_active_scene() { return *active_scene; };
+            Scene& get_active_scene() { return *open_scenes[selected_scene_index]; };
             RenderGraph& get_render_graph() { return *render_graph; };
+            const std::vector<std::shared_ptr<Scene>>& get_open_scenes() const { return open_scenes; };
+            u32 get_selected_scene_index() const { return selected_scene_index; };
 
             // @TODO: find a better way to pass values to the rest of the application (maybe use a struct?)
             u32& get_texture_output() { return settings_panel->get_texture_output(); };
@@ -60,7 +63,7 @@ namespace sprout
             void on_resize(WindowResizeEvent& e);
             void on_viewport_resize(const uvec2& new_viewport_size);
 
-            void set_active_scene(Scene* scene);
+            void set_active_scene(const u32 index);
             void build_render_graph(const uvec2& size, const uvec2& viewport_size);
 
             EventCallback event_callback;
@@ -77,8 +80,10 @@ namespace sprout
             std::unique_ptr<SettingsPanel> settings_panel;
 
             std::unique_ptr<RenderGraph> render_graph;
-            std::unique_ptr<Scene> active_scene;
-            std::vector<Scene*> scene_queue;
+            std::vector<std::shared_ptr<Scene>> open_scenes;
+
+            u32 selected_scene_index = 0;
+            u32 next_scene_index = 0;
 
             uvec2 curr_viewport_size;
             b8 disabled = false;

--- a/sprout_editor/src/editor.hpp
+++ b/sprout_editor/src/editor.hpp
@@ -34,6 +34,7 @@ namespace sprout
             virtual void on_event(Event& e) override;
 
             void add_scene(Scene* scene);
+            void close_scene(const std::shared_ptr<Scene>& scene);
 
             void set_input_disabled(const b8 disable);
             void set_selected_scene_index(const u32 index);
@@ -82,6 +83,7 @@ namespace sprout
 
             std::unique_ptr<RenderGraph> render_graph;
             std::vector<std::shared_ptr<Scene>> open_scenes;
+            std::vector<u32> open_scenes_marked_for_deletion;
 
             u32 selected_scene_index = 0;
             u32 next_scene_index = 0;

--- a/sprout_editor/src/menu/menu_bar.cpp
+++ b/sprout_editor/src/menu/menu_bar.cpp
@@ -113,7 +113,7 @@ namespace sprout
 
         scene_file_path = std::filesystem::path();
 
-        get_editor().enqueue_scene(scene);
+        get_editor().add_scene(scene);
 
         LOG_SUCCESS("Create new scene '{0}'", scene->get_name());
     }
@@ -156,7 +156,7 @@ namespace sprout
 
                         scene_file_path = file_path;
 
-                        editor.enqueue_scene(scene);
+                        editor.add_scene(scene);
 
                         LOG_SUCCESS("Loaded scene '{0}' from {1}", scene->get_name(), file_path);
                     }

--- a/sprout_editor/src/menu/menu_bar.cpp
+++ b/sprout_editor/src/menu/menu_bar.cpp
@@ -28,7 +28,7 @@ namespace sprout
             }
 
             // File
-            if (ImGui::BeginMenu((str(ICON_FA_FILE) + " File").c_str()))
+            if (ImGui::BeginMenu((str(ICON_FA_FILE) + " Scene").c_str()))
             {
                 // New
                 if (ImGui::MenuItem("New", "Ctrl+N"))
@@ -92,8 +92,10 @@ namespace sprout
 
     void MenuBar::save_active_scene_as()
     {
+        auto& scene = get_editor().get_active_scene();
+
         IGFD::FileDialogConfig config;
-        config.fileName = "untitled.mag.json";
+        config.fileName = scene.get_name() + ".mag.json";
 
         ImGuiFileDialog::Instance()->OpenDialog("ChooseFileDlgKey", "Save Scene", ".mag.json", config);
         set_dialog_action(DialogAction::Save);

--- a/sprout_editor/src/menu/menu_bar.cpp
+++ b/sprout_editor/src/menu/menu_bar.cpp
@@ -156,6 +156,8 @@ namespace sprout
 
                         scene_file_path = file_path;
 
+                        // @TODO: Check if scene isnt already opened.
+
                         editor.add_scene(scene);
 
                         LOG_SUCCESS("Loaded scene '{0}' from {1}", scene->get_name(), file_path);

--- a/sprout_editor/src/panels/viewport_panel.cpp
+++ b/sprout_editor/src/panels/viewport_panel.cpp
@@ -59,7 +59,8 @@ namespace sprout
             // Edit scene name
             static u32 edited_scene_index = INVALID_ID;
 
-            if (ImGui::BeginTabItem((open_scenes[i]->get_name() + tab_id).c_str()))
+            b8 open = true;
+            if (ImGui::BeginTabItem((open_scenes[i]->get_name() + tab_id).c_str(), &open))
             {
                 // Start editing field
                 if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left) && ImGui::IsItemHovered())
@@ -133,6 +134,13 @@ namespace sprout
                 }
 
                 ImGui::EndTabItem();
+            }
+
+            // Tab was closed, save the scene (one tab must always stay open).
+            if (!open && open_scenes.size() > 1)
+            {
+                editor.close_scene(open_scenes[i]);
+                continue;
             }
         }
 

--- a/sprout_editor/src/panels/viewport_panel.cpp
+++ b/sprout_editor/src/panels/viewport_panel.cpp
@@ -4,6 +4,7 @@
 #include "core/application.hpp"
 #include "editor.hpp"
 #include "icon_font_cpp/IconsFontAwesome6.h"
+#include "imgui/misc/cpp/imgui_stdlib.h"
 
 namespace sprout
 {
@@ -55,8 +56,32 @@ namespace sprout
         {
             const str tab_id = "##" + std::to_string(i);
 
+            // Edit scene name
+            static u32 edited_scene_index = INVALID_ID;
+
             if (ImGui::BeginTabItem((open_scenes[i]->get_name() + tab_id).c_str()))
             {
+                // Start editing field
+                if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left) && ImGui::IsItemHovered())
+                {
+                    edited_scene_index = i;
+                }
+
+                // Tab changed or lost focus -> quit editing
+                if (edited_scene_index != i || !ImGui::IsWindowFocused())
+                {
+                    edited_scene_index = INVALID_ID;
+                }
+
+                str name = open_scenes[i]->get_name();
+
+                if (edited_scene_index == i &&
+                    ImGui::InputText("##SceneNameClicked", &name, ImGuiInputTextFlags_EnterReturnsTrue))
+                {
+                    open_scenes[i]->set_name(name);
+                    edited_scene_index = INVALID_ID;
+                }
+
                 editor.set_selected_scene_index(i);
 
                 viewport_size = {ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y};


### PR DESCRIPTION
Missing features we would like to have
- [x] Button to close scenes
- [ ] Modified scene indicator next to the name (use `ImGuiTabItemFlags_UnsavedDocument`)
- [x] Editable scene name on double click
- [ ] Style baby

Some of these changes require a file watcher (and a proper dialog window) of sorts so we will probably implement them on the future