### PR TITLE
Simplifying gizmo rect calculation

### DIFF
--- a/sprout_editor/src/panels/viewport_panel.cpp
+++ b/sprout_editor/src/panels/viewport_panel.cpp
@@ -92,6 +92,9 @@ namespace sprout
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::Image(viewport_image_descriptor, ImVec2(viewport_size.x, viewport_size.y));
 
+                const auto image_pos = ImGui::GetItemRectMin();
+                viewport_position = {image_pos.x, image_pos.y};
+
                 // Load assets if any was draged over the viewport
                 if (ImGui::BeginDragDropTarget())
                 {
@@ -213,17 +216,8 @@ namespace sprout
             const mat4 scale_matrix = scale(mat4(1.0f), vec3(1, -1, 1));
             view = scale_matrix * view;
 
-            auto viewport_min_region = ImGui::GetWindowContentRegionMin();
-            auto viewport_max_region = ImGui::GetWindowContentRegionMax();
-            auto viewport_offset = ImGui::GetWindowPos();
-
-            vec2 viewport_bounds[2] = {
-                {viewport_min_region.x + viewport_offset.x, viewport_min_region.y + viewport_offset.y},
-                {viewport_max_region.x + viewport_offset.x, viewport_max_region.y + viewport_offset.y}};
-
             ImGuizmo::SetDrawlist();
-            ImGuizmo::SetRect(viewport_bounds[0].x, viewport_bounds[0].y, viewport_bounds[1].x - viewport_bounds[0].x,
-                              viewport_bounds[1].y - viewport_bounds[0].y);
+            ImGuizmo::SetRect(viewport_position.x, viewport_position.y, viewport_size.x, viewport_size.y);
 
             mat4 transform_matrix = transform->get_transformation_matrix();
 

--- a/sprout_editor/src/panels/viewport_panel.hpp
+++ b/sprout_editor/src/panels/viewport_panel.hpp
@@ -30,7 +30,7 @@ namespace sprout
             void on_key_press(KeyPressEvent& e);
 
             b8 viewport_window_active = false;
-            uvec2 viewport_size = {1, 1};
+            uvec2 viewport_size = {1, 1}, viewport_position = {0, 0};
             vk::DescriptorSet viewport_image_descriptor = {};
             ImGuizmo::OPERATION gizmo_operation = ImGuizmo::OPERATION::TRANSLATE;
     };


### PR DESCRIPTION
Fixes #72 

- [x] Use sprites for gizmos
- [ ] Use a gizmo library that is API agnostic (optional, not urgent or necessary )