### PR TITLE
Refactor/physics

### DIFF
--- a/magnolia/src/core/application.cpp
+++ b/magnolia/src/core/application.cpp
@@ -4,7 +4,6 @@
 #include "core/event.hpp"
 #include "core/logger.hpp"
 #include "core/window.hpp"
-#include "physics/physics.hpp"
 #include "platform/file_dialog.hpp"
 #include "platform/file_system.hpp"
 #include "renderer/renderer.hpp"
@@ -38,7 +37,6 @@ namespace mag
             unique<MaterialManager> material_manager;
             unique<ModelManager> model_manager;
             unique<ShaderManager> shader_manager;
-            unique<PhysicsEngine> physics_engine;
 
             b8 running;
             f32 target_frame_rate;
@@ -117,10 +115,6 @@ namespace mag
         impl->shader_manager = create_unique<ShaderManager>();
         LOG_SUCCESS("ShaderManager initialized");
 
-        // Create the physics engine
-        impl->physics_engine = create_unique<PhysicsEngine>();
-        LOG_SUCCESS("Physics initialized");
-
         // Initialize file dialogs
         if (FileDialog::initialize())
         {
@@ -153,8 +147,6 @@ namespace mag
                 impl->window->sleep(50);
                 continue;
             }
-
-            impl->physics_engine->on_update(dt);
 
             impl->job_system->process_callbacks();
 
@@ -206,5 +198,4 @@ namespace mag
     MaterialManager& Application::get_material_manager() { return *impl->material_manager; }
     ModelManager& Application::get_model_manager() { return *impl->model_manager; }
     ShaderManager& Application::get_shader_manager() { return *impl->shader_manager; }
-    PhysicsEngine& Application::get_physics_engine() { return *impl->physics_engine; }
 };  // namespace mag

--- a/magnolia/src/core/application.hpp
+++ b/magnolia/src/core/application.hpp
@@ -6,7 +6,6 @@ namespace mag
 {
     class Window;
     class Renderer;
-    class PhysicsEngine;
     class FileWatcher;
     class JobSystem;
 
@@ -43,7 +42,6 @@ namespace mag
             MaterialManager& get_material_manager();
             ModelManager& get_model_manager();
             ShaderManager& get_shader_manager();
-            PhysicsEngine& get_physics_engine();
 
         protected:
             // Process events from the user application

--- a/magnolia/src/ecs/components.cpp
+++ b/magnolia/src/ecs/components.cpp
@@ -38,8 +38,6 @@ namespace mag
 
     RigidBodyComponent::RigidBodyComponent(const f32 mass) : mass(mass) {}
 
-    b8 RigidBodyComponent::is_dynamic() const { return mass != 0.0f; }
-
     LightComponent::LightComponent(const vec3& color, const f32 intensity) : color(color), intensity(intensity) {}
 
     CameraComponent::CameraComponent(const Camera& camera) : camera(camera) {}

--- a/magnolia/src/ecs/components.hpp
+++ b/magnolia/src/ecs/components.hpp
@@ -85,7 +85,7 @@ namespace mag
             f32 mass;
 
             // Storage for physics engine use
-            u32 index = Invalid_ID;
+            void* collision_object = nullptr;
 
             b8 is_dynamic() const;
     };

--- a/magnolia/src/ecs/components.hpp
+++ b/magnolia/src/ecs/components.hpp
@@ -86,8 +86,6 @@ namespace mag
 
             // Storage for physics engine use
             void* collision_object = nullptr;
-
-            b8 is_dynamic() const;
     };
 
     struct LightComponent : public Component

--- a/magnolia/src/ecs/components.hpp
+++ b/magnolia/src/ecs/components.hpp
@@ -74,9 +74,6 @@ namespace mag
             CLONE_DECLARATION(BoxColliderComponent);
 
             vec3 dimensions;
-
-            // Storage for physics engine use
-            void* internal = nullptr;
     };
 
     struct RigidBodyComponent : public Component
@@ -88,7 +85,7 @@ namespace mag
             f32 mass;
 
             // Storage for physics engine use
-            void* internal = nullptr;
+            u32 index = Invalid_ID;
 
             b8 is_dynamic() const;
     };

--- a/magnolia/src/magnolia.hpp
+++ b/magnolia/src/magnolia.hpp
@@ -8,4 +8,6 @@
 #include "core/logger.hpp"
 #include "core/types.hpp"
 #include "core/window.hpp"
+#include "math/type_definitions.hpp"
+#include "physics/physics.hpp"
 #include "scene/scriptable_entity.hpp"

--- a/magnolia/src/physics/physics.cpp
+++ b/magnolia/src/physics/physics.cpp
@@ -125,7 +125,7 @@ namespace mag
     void PhysicsEngine::add_rigid_body(const TransformComponent& transform, BoxColliderComponent& collider,
                                        RigidBodyComponent& rigid_body)
     {
-        auto* shape = new btBoxShape(mag_vec_to_bt_vec(collider.dimensions));
+        btBoxShape* shape = new btBoxShape(mag_vec_to_bt_vec(collider.dimensions));
 
         // Rigidbody is dynamic if and only if mass is non zero, otherwise static
         btVector3 local_inertia(0, 0, 0);
@@ -137,10 +137,9 @@ namespace mag
 
         btRigidBody* bt_rigid_body = new btRigidBody(rb_info);
 
-        internal_data->dynamics_world->addRigidBody(bt_rigid_body);
+        rigid_body.index = internal_data->dynamics_world->getNumCollisionObjects();
 
-        collider.internal = shape;
-        rigid_body.internal = bt_rigid_body;
+        internal_data->dynamics_world->addRigidBody(bt_rigid_body);
     }
 
     void PhysicsEngine::remove_rigid_body(const u32 index)
@@ -178,7 +177,11 @@ namespace mag
             for (i32 i = objects.size() - 1; i >= 0; i--)
             {
                 auto [transform, rigid_body_c] = objects[i];
-                auto* body = static_cast<btRigidBody*>(rigid_body_c->internal);
+
+                btCollisionObject* bt_object =
+                    internal_data->dynamics_world->getCollisionObjectArray().at(rigid_body_c->index);
+
+                btRigidBody* body = static_cast<btRigidBody*>(bt_object);
 
                 btTransform trans(btQuaternion(0, 0, 0, 0));
 

--- a/magnolia/src/physics/physics.cpp
+++ b/magnolia/src/physics/physics.cpp
@@ -204,6 +204,48 @@ namespace mag
         internal_data->dynamics_world->debugDrawWorld();
     }
 
+    void PhysicsEngine::apply_force(const u32 object_index, const math::vec3& force)
+    {
+        btCollisionObject* bt_object = internal_data->dynamics_world->getCollisionObjectArray().at(object_index);
+
+        btRigidBody* body = static_cast<btRigidBody*>(bt_object);
+
+        body->applyCentralForce(mag_vec_to_bt_vec(force));
+    }
+
+    void PhysicsEngine::apply_impulse(const u32 object_index, const math::vec3& impulse)
+    {
+        btCollisionObject* bt_object = internal_data->dynamics_world->getCollisionObjectArray().at(object_index);
+
+        btRigidBody* body = static_cast<btRigidBody*>(bt_object);
+
+        // Don't forget to activate the body if it's sleeping
+        body->activate(true);
+
+        body->applyCentralImpulse(mag_vec_to_bt_vec(impulse));
+    }
+
+    void PhysicsEngine::apply_torque(const u32 object_index, const math::vec3& torque)
+    {
+        btCollisionObject* bt_object = internal_data->dynamics_world->getCollisionObjectArray().at(object_index);
+
+        btRigidBody* body = static_cast<btRigidBody*>(bt_object);
+
+        body->applyTorque(mag_vec_to_bt_vec(torque));
+    }
+
+    void PhysicsEngine::apply_torque_impulse(const u32 object_index, const math::vec3& torque)
+    {
+        btCollisionObject* bt_object = internal_data->dynamics_world->getCollisionObjectArray().at(object_index);
+
+        btRigidBody* body = static_cast<btRigidBody*>(bt_object);
+
+        // Don't forget to activate the body if it's sleeping
+        body->activate(true);
+
+        body->applyTorqueImpulse(mag_vec_to_bt_vec(torque));
+    }
+
     const LineList& PhysicsEngine::get_line_list() const { return physics_debug_draw->get_line_list(); };
 
     void PhysicsDebugDraw::reset_lines()

--- a/magnolia/src/physics/physics.hpp
+++ b/magnolia/src/physics/physics.hpp
@@ -10,47 +10,44 @@ namespace mag::math
 
 namespace mag
 {
-    class PhysicsDebugDraw;
-    class Scene;
-
-    struct PhysicsInternalData;
-    struct TransformComponent;
-    struct BoxColliderComponent;
-    struct RigidBodyComponent;
-
-    class PhysicsEngine
+    class PhysicsWorld
     {
         public:
-            PhysicsEngine();
-            ~PhysicsEngine();
-
-            void on_simulation_start(Scene* scene);
-            void on_simulation_end();
+            PhysicsWorld();
+            ~PhysicsWorld();
 
             void on_update(const f32 dt);
 
+            void* add_rigid_body(const math::vec3& position, const math::quat& rotation,
+                                 const math::vec3& collider_dimensions, const f32 mass) const;
+
+            void remove_rigid_body(void* collision_object);
+
+            void reset_rigid_body(void* collision_object, const math::vec3& position, const math::vec3& rotation,
+                                  const math::vec3& collider_dimensions, const f32 mass = -1.0f) const;
+
             // Applies continuous force over time
-            void apply_force(const u32 object_index, const math::vec3& force);
+            void apply_force(void* collision_object, const math::vec3& force);
 
             // Applies an instantaneous change in momentum
-            void apply_impulse(const u32 object_index, const math::vec3& impulse);
+            void apply_impulse(void* collision_object, const math::vec3& impulse);
 
             // Applies continuous torque over time
-            void apply_torque(const u32 object_index, const math::vec3& force);
+            void apply_torque(void* collision_object, const math::vec3& force);
 
-            // Applies an instantaneous change in momentum
-            void apply_torque_impulse(const u32 object_index, const math::vec3& force);
+            // Applies an instantaneous change in torque
+            void apply_torque_impulse(void* collision_object, const math::vec3& force);
+
+            // Get current transform of a collision object
+            void get_collision_object_transform(void* collision_object, math::vec3& position,
+                                                math::vec3& rotation) const;
 
             const math::LineList& get_line_list() const;
 
         private:
-            void add_rigid_body(const TransformComponent& transform, BoxColliderComponent& collider,
-                                RigidBodyComponent& rigid_body);
+            void render_debug_lines();
 
-            void remove_rigid_body(const u32 index);
-
-            PhysicsInternalData* internal_data;
-            unique<PhysicsDebugDraw> physics_debug_draw;
-            Scene* scene;
+            struct PhysicsInternalData* internal_data = nullptr;
+            unique<class PhysicsDebugDraw> physics_debug_draw;
     };
 };  // namespace mag

--- a/magnolia/src/physics/physics.hpp
+++ b/magnolia/src/physics/physics.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/types.hpp"
+#include "math/types.hpp"
 
 namespace mag::math
 {
@@ -27,6 +28,18 @@ namespace mag
             void on_simulation_end();
 
             void on_update(const f32 dt);
+
+            // Applies continuous force over time
+            void apply_force(const u32 object_index, const math::vec3& force);
+
+            // Applies an instantaneous change in momentum
+            void apply_impulse(const u32 object_index, const math::vec3& impulse);
+
+            // Applies continuous torque over time
+            void apply_torque(const u32 object_index, const math::vec3& force);
+
+            // Applies an instantaneous change in momentum
+            void apply_torque_impulse(const u32 object_index, const math::vec3& force);
 
             const math::LineList& get_line_list() const;
 

--- a/magnolia/src/private/physics_type_conversions.cpp
+++ b/magnolia/src/private/physics_type_conversions.cpp
@@ -22,7 +22,20 @@ namespace mag
         return bt_transform;
     }
 
-    TransformComponent const bt_transform_to_mag_transform(const btTransform& t, const vec3& scale)
+    btTransform const mag_transform_to_bt_transform(const math::vec3& position, const math::quat& rotation)
+    {
+        btTransform bt_transform;
+        bt_transform.setIdentity();
+        bt_transform.setOrigin(mag_vec_to_bt_vec(position));
+
+        const btQuaternion q(rotation.x, rotation.y, rotation.z, rotation.w);
+
+        bt_transform.setRotation(q);
+
+        return bt_transform;
+    }
+
+    TransformComponent const bt_transform_to_mag_transform(const btTransform& t)
     {
         TransformComponent transform;
         transform.translation = math::vec3(t.getOrigin().getX(), t.getOrigin().getY(), t.getOrigin().getZ());
@@ -30,9 +43,6 @@ namespace mag
         btScalar pitch, yaw, roll;
         t.getRotation().getEulerZYX(roll, yaw, pitch);
         transform.rotation = degrees(vec3(pitch, yaw, roll));
-
-        // btTransform has no scale so we need to ask the user for that value
-        transform.scale = scale;
 
         return transform;
     }

--- a/magnolia/src/private/physics_type_conversions.hpp
+++ b/magnolia/src/private/physics_type_conversions.hpp
@@ -10,7 +10,8 @@ namespace mag
     struct TransformComponent;
 
     btTransform const mag_transform_to_bt_transform(const TransformComponent& t);
-    TransformComponent const bt_transform_to_mag_transform(const btTransform& t, const math::vec3& scale);
+    btTransform const mag_transform_to_bt_transform(const math::vec3& position, const math::quat& rotation);
+    TransformComponent const bt_transform_to_mag_transform(const btTransform& t);
     btVector3 const mag_vec_to_bt_vec(const math::vec3& v);
     math::vec3 const bt_vec_to_mag_vec(const btVector3& bt_vec);
 };  // namespace mag

--- a/magnolia/src/scene/scene.hpp
+++ b/magnolia/src/scene/scene.hpp
@@ -8,6 +8,7 @@ namespace mag
 {
     class ECS;
     class Camera;
+    class PhysicsWorld;
     struct Component;
 
     class Scene
@@ -34,6 +35,7 @@ namespace mag
             b8 is_running() const;
 
             const str& get_name() const;
+            const PhysicsWorld* get_physics_world() const;
             ECS& get_ecs();
             virtual Camera& get_camera();
 
@@ -43,13 +45,18 @@ namespace mag
             virtual void on_stop_internal();
             virtual void on_event_internal(const Event& e);
             virtual void on_update_internal(const f32 dt);
+            virtual void on_component_added_internal(const u32 id, Component* component);
             virtual void on_resize(const WindowResizeEvent& e);
-            virtual void on_component_added(const u32 id, Component* component);
 
             str name;
             unique<ECS> ecs;
+            unique<PhysicsWorld> physics_world;
 
         private:
+            void on_component_added(const u32 id, Component* component);
+            void instantiate_scripts();
+            void destroy_scripts();
+
             std::vector<u32> entity_deletion_queue;
             b8 running = false;
     };

--- a/magnolia/src/scene/scriptable_entity.cpp
+++ b/magnolia/src/scene/scriptable_entity.cpp
@@ -11,4 +11,5 @@ namespace mag
     void ScriptableEntity::on_destroy() {}
     void ScriptableEntity::on_update(const f32 dt) { (void)dt; }
     void ScriptableEntity::on_event(const Event& e) { (void)e; }
+    PhysicsWorld& ScriptableEntity::get_physics_world() const { return *physics_world; }
 };  // namespace mag

--- a/magnolia/src/scene/scriptable_entity.hpp
+++ b/magnolia/src/scene/scriptable_entity.hpp
@@ -6,6 +6,7 @@
 namespace mag
 {
     struct Event;
+    class PhysicsWorld;
 
     class ScriptableEntity
     {
@@ -31,9 +32,12 @@ namespace mag
                 return ecs->get_components<Ts...>(entity_id);
             }
 
+            PhysicsWorld& get_physics_world() const;
+
         private:
             friend class Scene;
 
+            PhysicsWorld* physics_world = nullptr;
             ECS* ecs = nullptr;
             u32 entity_id;
     };

--- a/sprout_editor/assets/scenes/Test.mag.json
+++ b/sprout_editor/assets/scenes/Test.mag.json
@@ -27,7 +27,7 @@
                 "Fov": 60.0,
                 "Near": 1.0,
                 "Far": 10000.0,
-                "AspectRatio": 1.7285945415496826
+                "AspectRatio": 1.7302100658416748
             },
             "ScriptComponent": {
                 "FilePath": "sprout_editor/assets/scripts/example_script.cpp"
@@ -93,6 +93,153 @@
                     1.0
                 ],
                 "Intensity": 100.0
+            }
+        },
+        {
+            "NameComponent": {
+                "Name": "Entity3"
+            },
+            "TransformComponent": {
+                "Translation": [
+                    0.0,
+                    87.581787109375,
+                    0.0
+                ],
+                "Rotation": [
+                    0.0,
+                    -0.0,
+                    0.0
+                ],
+                "Scale": [
+                    100.0,
+                    100.0,
+                    100.0
+                ]
+            },
+            "ModelComponent": {
+                "Name": "wooden_hammer_01",
+                "FilePath": "sprout_editor/assets/models/hammer/native/wooden_hammer_01.model.json"
+            },
+            "BoxColliderComponent": {
+                "Dimensions": [
+                    10.0,
+                    10.0,
+                    5.0
+                ]
+            },
+            "RigidBodyComponent": {
+                "Mass": 1.0
+            },
+            "ScriptComponent": {
+                "FilePath": "sprout_editor/assets/scripts/physics_script.cpp"
+            }
+        },
+        {
+            "NameComponent": {
+                "Name": "Entity4"
+            },
+            "TransformComponent": {
+                "Translation": [
+                    32.96977233886719,
+                    87.581787109375,
+                    0.0
+                ],
+                "Rotation": [
+                    0.0,
+                    -0.0,
+                    0.0
+                ],
+                "Scale": [
+                    100.0,
+                    100.0,
+                    100.0
+                ]
+            },
+            "ModelComponent": {
+                "Name": "wooden_hammer_01",
+                "FilePath": "sprout_editor/assets/models/hammer/native/wooden_hammer_01.model.json"
+            },
+            "BoxColliderComponent": {
+                "Dimensions": [
+                    10.0,
+                    10.0,
+                    5.0
+                ]
+            },
+            "RigidBodyComponent": {
+                "Mass": 1.0
+            }
+        },
+        {
+            "NameComponent": {
+                "Name": "Entity5"
+            },
+            "TransformComponent": {
+                "Translation": [
+                    62.54661560058594,
+                    87.581787109375,
+                    0.0
+                ],
+                "Rotation": [
+                    0.0,
+                    -0.0,
+                    0.0
+                ],
+                "Scale": [
+                    100.0,
+                    100.0,
+                    100.0
+                ]
+            },
+            "ModelComponent": {
+                "Name": "wooden_hammer_01",
+                "FilePath": "sprout_editor/assets/models/hammer/native/wooden_hammer_01.model.json"
+            },
+            "BoxColliderComponent": {
+                "Dimensions": [
+                    10.0,
+                    10.0,
+                    5.0
+                ]
+            },
+            "RigidBodyComponent": {
+                "Mass": 1.0
+            }
+        },
+        {
+            "NameComponent": {
+                "Name": "Entity6"
+            },
+            "TransformComponent": {
+                "Translation": [
+                    103.64220428466797,
+                    87.581787109375,
+                    0.0
+                ],
+                "Rotation": [
+                    0.0,
+                    -0.0,
+                    0.0
+                ],
+                "Scale": [
+                    100.0,
+                    100.0,
+                    100.0
+                ]
+            },
+            "ModelComponent": {
+                "Name": "wooden_hammer_01",
+                "FilePath": "sprout_editor/assets/models/hammer/native/wooden_hammer_01.model.json"
+            },
+            "BoxColliderComponent": {
+                "Dimensions": [
+                    10.0,
+                    10.0,
+                    5.0
+                ]
+            },
+            "RigidBodyComponent": {
+                "Mass": 1.0
             }
         }
     ]

--- a/sprout_editor/assets/scripts/physics_script.cpp
+++ b/sprout_editor/assets/scripts/physics_script.cpp
@@ -1,0 +1,36 @@
+#include <magnolia.hpp>
+
+using namespace mag;
+
+class PhysicsController : public ScriptableEntity
+{
+    public:
+        virtual void on_create() override { LOG_SUCCESS("Created PhysicsController"); }
+
+        virtual void on_destroy() override { LOG_SUCCESS("Destroyed PhysicsController"); }
+
+        virtual void on_update(const f32 dt) override
+        {
+            auto& app = get_application();
+            auto& window = get_application().get_window();
+            auto& physics = app.get_physics_engine();
+
+            auto [transform, rigidbody] = get_components<TransformComponent, RigidBodyComponent>();
+            if (!transform || !rigidbody)
+            {
+                LOG_WARNING("(PhysicsController) Missing transform/rigidbody");
+                return;
+            }
+
+            if (window.is_key_pressed(Key::i))
+            {
+                const vec3 impulse = vec3(0, 2000, 0) * dt;
+                physics.apply_impulse(rigidbody->index, impulse);
+            }
+        }
+
+        virtual void on_event(const Event& e) override { (void)e; }
+};
+
+extern "C" ScriptableEntity* create_script() { return new PhysicsController(); }
+extern "C" void destroy_script(ScriptableEntity* script) { delete script; }

--- a/sprout_editor/assets/scripts/physics_script.cpp
+++ b/sprout_editor/assets/scripts/physics_script.cpp
@@ -11,9 +11,9 @@ class PhysicsController : public ScriptableEntity
 
         virtual void on_update(const f32 dt) override
         {
-            auto& app = get_application();
-            auto& window = get_application().get_window();
-            auto& physics = app.get_physics_engine();
+            Application& app = get_application();
+            Window& window = app.get_window();
+            PhysicsWorld& physics_world = get_physics_world();
 
             auto [transform, rigidbody] = get_components<TransformComponent, RigidBodyComponent>();
             if (!transform || !rigidbody)
@@ -25,7 +25,7 @@ class PhysicsController : public ScriptableEntity
             if (window.is_key_pressed(Key::i))
             {
                 const vec3 impulse = vec3(0, 2000, 0) * dt;
-                physics.apply_impulse(rigidbody->index, impulse);
+                physics_world.apply_torque_impulse(rigidbody->collision_object, impulse);
             }
         }
 

--- a/sprout_editor/src/editor.cpp
+++ b/sprout_editor/src/editor.cpp
@@ -348,9 +348,6 @@ namespace sprout
 
     void Editor::set_active_scene(const u32 index)
     {
-        auto &app = get_application();
-        auto &physics_engine = app.get_physics_engine();
-
         auto &active_scene = get_active_scene();
         if (active_scene.is_running())
         {
@@ -358,8 +355,6 @@ namespace sprout
         }
 
         impl->selected_scene_index = math::clamp(index, 0u, static_cast<u32>(impl->open_scenes.size() - 1));
-
-        physics_engine.on_simulation_start(impl->open_scenes[impl->selected_scene_index].get());
     }
 
     void Editor::set_input_disabled(const b8 disable) { impl->disabled = disable; }

--- a/sprout_editor/src/editor_scene.cpp
+++ b/sprout_editor/src/editor_scene.cpp
@@ -6,6 +6,7 @@
 #include "core/window.hpp"
 #include "ecs/components.hpp"
 #include "ecs/ecs.hpp"
+#include "physics/physics.hpp"
 #include "platform/file_system.hpp"
 #include "threads/job_system.hpp"
 
@@ -38,6 +39,15 @@ namespace sprout
         ecs.reset();
         ecs = create_unique<ECS>(*temporary_ecs);
         temporary_ecs.reset();
+
+        // Reset physics world state
+        auto objects = ecs->get_all_components_of_types<TransformComponent, RigidBodyComponent, BoxColliderComponent>();
+
+        for (auto [transform, rigid_body, collider] : objects)
+        {
+            physics_world->reset_rigid_body(rigid_body->collision_object, transform->translation, transform->rotation,
+                                            collider->dimensions, rigid_body->mass);
+        }
     }
 
     void EditorScene::on_update_internal(const f32 dt)
@@ -131,7 +141,7 @@ namespace sprout
         job_system.add_job(load_job);
     }
 
-    void EditorScene::on_component_added(const u32 id, Component* component)
+    void EditorScene::on_component_added_internal(const u32 id, Component* component)
     {
         (void)id;
 

--- a/sprout_editor/src/editor_scene.hpp
+++ b/sprout_editor/src/editor_scene.hpp
@@ -32,7 +32,7 @@ namespace sprout
             virtual void on_event_internal(const Event& e) override;
             virtual void on_update_internal(const f32 dt) override;
             virtual void on_resize(const WindowResizeEvent& e) override;
-            virtual void on_component_added(const u32 id, Component* component) override;
+            virtual void on_component_added_internal(const u32 id, Component* component) override;
 
         private:
             unique<ECS> temporary_ecs;

--- a/sprout_editor/src/passes/editor_pass.cpp
+++ b/sprout_editor/src/passes/editor_pass.cpp
@@ -117,8 +117,8 @@ namespace sprout
         auto& app = get_application();
         auto& renderer = app.get_renderer();
         auto& editor = get_editor();
-        auto& physics_engine = app.get_physics_engine();
         auto& scene = editor.get_active_scene();
+        auto* physics_world = scene.get_physics_world();
         const auto& camera = scene.get_camera();
 
         lines.reset(nullptr);
@@ -155,9 +155,9 @@ namespace sprout
 
         // Get lines from physics
 
-        if (editor.is_physics_colliders_enabled())
+        if (editor.is_physics_colliders_enabled() && physics_world != nullptr)
         {
-            const auto& physics_lines = physics_engine.get_line_list();
+            const auto& physics_lines = physics_world->get_line_list();
 
             if (!physics_lines.starts.empty())
             {


### PR DESCRIPTION
Refactoring physics API:
- Separating scene logic from the physics API. The scene or other systems are responsible for handling and updating the ECS's state. The physics system only job is to run the physics simulation.
- To make data management more flexible, the physics system is now created in a world. Objects can be added/removed from the world as needed. Handling the physics objects lifetime/state is the responsibility of the user but the physics system does free the memory associated with every object when the world is destroyed.
- Objects that are created can be referenced by a handle. The user can now apply forces and torque to an object in a physics world by using the provided handle.
- Debug features have also been improved to better reflect the state of the physics world.